### PR TITLE
Include first attempts in answer distribution

### DIFF
--- a/analytics_data_api/utils.py
+++ b/analytics_data_api/utils.py
@@ -3,6 +3,8 @@ from collections import defaultdict
 from django.db.models import Q
 from rest_framework.authtoken.models import Token
 
+from analytics_data_api.v0.models import ProblemResponseAnswerDistribution
+
 
 def delete_user_auth_token(username):
     """
@@ -77,7 +79,11 @@ def consolidate_answers(problem):
                 consolidated_answer.variant = None
                 consolidated_answer.consolidated_variant = True
             else:
-                consolidated_answer.count += answer.count
+                if type(consolidated_answer) == ProblemResponseAnswerDistribution:
+                    consolidated_answer.count += answer.count
+                else:
+                    consolidated_answer.first_response_count += answer.first_response_count
+                    consolidated_answer.final_response_count += answer.final_response_count
 
         consolidated_answers.append(consolidated_answer)
 

--- a/analytics_data_api/utils.py
+++ b/analytics_data_api/utils.py
@@ -73,17 +73,17 @@ def consolidate_answers(problem):
             continue
 
         for answer in answers:
-            if not consolidated_answer:
-                consolidated_answer = answer
-
-                consolidated_answer.variant = None
-                consolidated_answer.consolidated_variant = True
-            else:
+            if consolidated_answer:
                 if type(consolidated_answer) == ProblemResponseAnswerDistribution:
                     consolidated_answer.count += answer.count
                 else:
                     consolidated_answer.first_response_count += answer.first_response_count
                     consolidated_answer.final_response_count += answer.final_response_count
+            else:
+                consolidated_answer = answer
+
+                consolidated_answer.variant = None
+                consolidated_answer.consolidated_variant = True
 
         consolidated_answers.append(consolidated_answer)
 

--- a/analytics_data_api/utils.py
+++ b/analytics_data_api/utils.py
@@ -78,7 +78,7 @@ def consolidate_answers(problem):
                     consolidated_answer.count += answer.count
                 else:
                     consolidated_answer.first_response_count += answer.first_response_count
-                    consolidated_answer.final_response_count += answer.final_response_count
+                    consolidated_answer.last_response_count += answer.last_response_count
             else:
                 consolidated_answer = answer
 

--- a/analytics_data_api/v0/models.py
+++ b/analytics_data_api/v0/models.py
@@ -121,14 +121,14 @@ class ProblemResponseAnswerDistribution(BaseProblemResponseAnswerDistribution):
     count = models.IntegerField()
 
 
-class ProblemFirstFinalResponseAnswerDistribution(BaseProblemResponseAnswerDistribution):
-    """ Updated model for answer_distribution table with counts of first and final attempts at problems. """
+class ProblemFirstLastResponseAnswerDistribution(BaseProblemResponseAnswerDistribution):
+    """ Updated model for answer_distribution table with counts of first and last attempts at problems. """
 
     class Meta(BaseProblemResponseAnswerDistribution.Meta):
         verbose_name = 'first_last_answer_distribution'
 
     first_response_count = models.IntegerField()
-    final_response_count = models.IntegerField()
+    last_response_count = models.IntegerField()
 
 
 class CourseEnrollmentByCountry(BaseCourseEnrollment):

--- a/analytics_data_api/v0/models.py
+++ b/analytics_data_api/v0/models.py
@@ -121,8 +121,8 @@ class ProblemResponseAnswerDistribution(BaseProblemResponseAnswerDistribution):
     count = models.IntegerField()
 
 
-class ProblemFirstLastResponseAnswerDistribution(BaseProblemResponseAnswerDistribution):
-    """ Updated model for answer_distribution table including a count of first attempts at problems. """
+class ProblemFirstFinalResponseAnswerDistribution(BaseProblemResponseAnswerDistribution):
+    """ Updated model for answer_distribution table with counts of first and final attempts at problems. """
 
     class Meta(BaseProblemResponseAnswerDistribution.Meta):
         verbose_name = 'first_last_answer_distribution'

--- a/analytics_data_api/v0/models.py
+++ b/analytics_data_api/v0/models.py
@@ -93,23 +93,42 @@ class CourseEnrollmentByGender(BaseCourseEnrollment):
         unique_together = [('course_id', 'date', 'gender')]
 
 
-class ProblemResponseAnswerDistribution(models.Model):
-    """ Each row stores the count of a particular answer to a response in a problem in a course (usage). """
+class BaseProblemResponseAnswerDistribution(models.Model):
+    """ Base model for the answer_distribution table. """
 
     class Meta(object):
         db_table = 'answer_distribution'
+        abstract = True
 
     course_id = models.CharField(db_index=True, max_length=255)
     module_id = models.CharField(db_index=True, max_length=255)
     part_id = models.CharField(db_index=True, max_length=255)
     correct = models.NullBooleanField()
-    count = models.IntegerField()
     value_id = models.CharField(db_index=True, max_length=255, null=True)
     answer_value = models.TextField(null=True, db_column='answer_value_text')
     variant = models.IntegerField(null=True)
     problem_display_name = models.TextField(null=True)
     question_text = models.TextField(null=True)
     created = models.DateTimeField(auto_now_add=True)
+
+
+class ProblemResponseAnswerDistribution(BaseProblemResponseAnswerDistribution):
+    """ Original model for the count of a particular answer to a response to a problem in a course. """
+
+    class Meta(BaseProblemResponseAnswerDistribution.Meta):
+        managed = False
+
+    count = models.IntegerField()
+
+
+class ProblemFirstLastResponseAnswerDistribution(BaseProblemResponseAnswerDistribution):
+    """ Updated model for answer_distribution table including a count of first attempts at problems. """
+
+    class Meta(BaseProblemResponseAnswerDistribution.Meta):
+        verbose_name = 'first_last_answer_distribution'
+
+    first_response_count = models.IntegerField()
+    final_response_count = models.IntegerField()
 
 
 class CourseEnrollmentByCountry(BaseCourseEnrollment):

--- a/analytics_data_api/v0/serializers.py
+++ b/analytics_data_api/v0/serializers.py
@@ -99,7 +99,7 @@ class ConsolidatedAnswerDistributionSerializer(ProblemResponseAnswerDistribution
         return distribution
 
 
-class ProblemFirstFinalResponseAnswerDistributionSerializer(ProblemResponseAnswerDistributionSerializer):
+class ProblemFirstLastResponseAnswerDistributionSerializer(ProblemResponseAnswerDistributionSerializer):
     """
     Serializer for answer distribution table including counts of first and last response values.
     """
@@ -108,10 +108,10 @@ class ProblemFirstFinalResponseAnswerDistributionSerializer(ProblemResponseAnswe
     count = serializers.IntegerField()
 
     class Meta(ProblemResponseAnswerDistributionSerializer.Meta):
-        model = models.ProblemFirstFinalResponseAnswerDistribution
+        model = models.ProblemFirstLastResponseAnswerDistribution
         fields = ProblemResponseAnswerDistributionSerializer.Meta.fields + (
             'first_response_count',
-            'final_response_count',
+            'last_response_count',
         )
 
         # XXX: This should be uncommented when versioning is implemented.
@@ -125,22 +125,22 @@ class ProblemFirstFinalResponseAnswerDistributionSerializer(ProblemResponseAnswe
         """
 
         count = attrs.pop('count', None)
-        distribution = super(ProblemFirstFinalResponseAnswerDistributionSerializer, self).restore_object(
+        distribution = super(ProblemFirstLastResponseAnswerDistributionSerializer, self).restore_object(
             attrs, instance)
         distribution.count = count
 
         return distribution
 
 
-class ConsolidatedFirstFinalAnswerDistributionSerializer(ProblemFirstFinalResponseAnswerDistributionSerializer):
+class ConsolidatedFirstLastAnswerDistributionSerializer(ProblemFirstLastResponseAnswerDistributionSerializer):
     """
     Serializer for consolidated answer distributions including first attempt counts.
     """
 
     consolidated_variant = serializers.BooleanField()
 
-    class Meta(ProblemFirstFinalResponseAnswerDistributionSerializer.Meta):
-        fields = ProblemFirstFinalResponseAnswerDistributionSerializer.Meta.fields + ('consolidated_variant',)
+    class Meta(ProblemFirstLastResponseAnswerDistributionSerializer.Meta):
+        fields = ProblemFirstLastResponseAnswerDistributionSerializer.Meta.fields + ('consolidated_variant',)
 
     # pylint: disable=super-on-old-class
     def restore_object(self, attrs, instance=None):
@@ -149,7 +149,7 @@ class ConsolidatedFirstFinalAnswerDistributionSerializer(ProblemFirstFinalRespon
         """
 
         consolidated_variant = attrs.pop('consolidated_variant', None)
-        distribution = super(ConsolidatedFirstFinalAnswerDistributionSerializer, self).restore_object(attrs, instance)
+        distribution = super(ConsolidatedFirstLastAnswerDistributionSerializer, self).restore_object(attrs, instance)
         distribution.consolidated_variant = consolidated_variant
 
         return distribution

--- a/analytics_data_api/v0/serializers.py
+++ b/analytics_data_api/v0/serializers.py
@@ -104,13 +104,32 @@ class ProblemFirstFinalResponseAnswerDistributionSerializer(ProblemResponseAnswe
     Serializer for answer distribution table including counts of first and last response values.
     """
 
+    # XXX: This field should be removed when versioning is implemented.
+    count = serializers.IntegerField()
+
     class Meta(ProblemResponseAnswerDistributionSerializer.Meta):
         model = models.ProblemFirstFinalResponseAnswerDistribution
         fields = ProblemResponseAnswerDistributionSerializer.Meta.fields + (
             'first_response_count',
             'final_response_count',
         )
-        fields = tuple([field for field in fields if field != 'count'])
+
+        # XXX: This should be uncommented when versioning is implemented.
+        # fields = tuple([field for field in fields if field != 'count'])
+
+    # XXX: This duplicate field should be removed when correct versioning is implemented.
+    # pylint: disable=super-on-old-class
+    def restore_object(self, attrs, instance=None):
+        """
+        Pops and restores non-model field.
+        """
+
+        count = attrs.pop('count', None)
+        distribution = super(ProblemFirstFinalResponseAnswerDistributionSerializer, self).restore_object(
+            attrs, instance)
+        distribution.count = count
+
+        return distribution
 
 
 class ConsolidatedFirstFinalAnswerDistributionSerializer(ProblemFirstFinalResponseAnswerDistributionSerializer):

--- a/analytics_data_api/v0/serializers.py
+++ b/analytics_data_api/v0/serializers.py
@@ -106,7 +106,10 @@ class ProblemFirstLastResponseAnswerDistributionSerializer(ProblemResponseAnswer
 
     class Meta(ProblemResponseAnswerDistributionSerializer.Meta):
         model = models.ProblemFirstLastResponseAnswerDistribution
-        fields = ProblemResponseAnswerDistributionSerializer.Meta.fields + ('first_response_count', 'final_response_count')
+        fields = ProblemResponseAnswerDistributionSerializer.Meta.fields + (
+            'first_response_count',
+            'final_response_count',
+        )
         fields = tuple([field for field in fields if field != 'count'])
 
 

--- a/analytics_data_api/v0/serializers.py
+++ b/analytics_data_api/v0/serializers.py
@@ -99,13 +99,13 @@ class ConsolidatedAnswerDistributionSerializer(ProblemResponseAnswerDistribution
         return distribution
 
 
-class ProblemFirstLastResponseAnswerDistributionSerializer(ProblemResponseAnswerDistributionSerializer):
+class ProblemFirstFinalResponseAnswerDistributionSerializer(ProblemResponseAnswerDistributionSerializer):
     """
     Serializer for answer distribution table including counts of first and last response values.
     """
 
     class Meta(ProblemResponseAnswerDistributionSerializer.Meta):
-        model = models.ProblemFirstLastResponseAnswerDistribution
+        model = models.ProblemFirstFinalResponseAnswerDistribution
         fields = ProblemResponseAnswerDistributionSerializer.Meta.fields + (
             'first_response_count',
             'final_response_count',
@@ -113,15 +113,15 @@ class ProblemFirstLastResponseAnswerDistributionSerializer(ProblemResponseAnswer
         fields = tuple([field for field in fields if field != 'count'])
 
 
-class ConsolidatedFirstLastAnswerDistributionSerializer(ProblemFirstLastResponseAnswerDistributionSerializer):
+class ConsolidatedFirstFinalAnswerDistributionSerializer(ProblemFirstFinalResponseAnswerDistributionSerializer):
     """
     Serializer for consolidated answer distributions including first attempt counts.
     """
 
     consolidated_variant = serializers.BooleanField()
 
-    class Meta(ProblemFirstLastResponseAnswerDistributionSerializer.Meta):
-        fields = ProblemFirstLastResponseAnswerDistributionSerializer.Meta.fields + ('consolidated_variant',)
+    class Meta(ProblemFirstFinalResponseAnswerDistributionSerializer.Meta):
+        fields = ProblemFirstFinalResponseAnswerDistributionSerializer.Meta.fields + ('consolidated_variant',)
 
     # pylint: disable=super-on-old-class
     def restore_object(self, attrs, instance=None):
@@ -130,7 +130,7 @@ class ConsolidatedFirstLastAnswerDistributionSerializer(ProblemFirstLastResponse
         """
 
         consolidated_variant = attrs.pop('consolidated_variant', None)
-        distribution = super(ConsolidatedFirstLastAnswerDistributionSerializer, self).restore_object(attrs, instance)
+        distribution = super(ConsolidatedFirstFinalAnswerDistributionSerializer, self).restore_object(attrs, instance)
         distribution.consolidated_variant = consolidated_variant
 
         return distribution

--- a/analytics_data_api/v0/serializers.py
+++ b/analytics_data_api/v0/serializers.py
@@ -99,6 +99,40 @@ class ConsolidatedAnswerDistributionSerializer(ProblemResponseAnswerDistribution
         return distribution
 
 
+class ProblemFirstLastResponseAnswerDistributionSerializer(ProblemResponseAnswerDistributionSerializer):
+    """
+    Serializer for answer distribution table including counts of first and last response values.
+    """
+
+    class Meta(ProblemResponseAnswerDistributionSerializer.Meta):
+        model = models.ProblemFirstLastResponseAnswerDistribution
+        fields = ProblemResponseAnswerDistributionSerializer.Meta.fields + ('first_response_count', 'final_response_count')
+        fields = tuple([field for field in fields if field != 'count'])
+
+
+class ConsolidatedFirstLastAnswerDistributionSerializer(ProblemFirstLastResponseAnswerDistributionSerializer):
+    """
+    Serializer for consolidated answer distributions including first attempt counts.
+    """
+
+    consolidated_variant = serializers.BooleanField()
+
+    class Meta(ProblemFirstLastResponseAnswerDistributionSerializer.Meta):
+        fields = ProblemFirstLastResponseAnswerDistributionSerializer.Meta.fields + ('consolidated_variant',)
+
+    # pylint: disable=super-on-old-class
+    def restore_object(self, attrs, instance=None):
+        """
+        Pops and restores non-model field.
+        """
+
+        consolidated_variant = attrs.pop('consolidated_variant', None)
+        distribution = super(ConsolidatedFirstLastAnswerDistributionSerializer, self).restore_object(attrs, instance)
+        distribution.consolidated_variant = consolidated_variant
+
+        return distribution
+
+
 class GradeDistributionSerializer(ModelSerializerWithCreatedField):
     """
     Representation of the grade_distribution table without id

--- a/analytics_data_api/v0/tests/views/test_courses.py
+++ b/analytics_data_api/v0/tests/views/test_courses.py
@@ -598,7 +598,7 @@ class CourseProblemsListViewTests(DemoCourseMixin, TestCaseWithAuthentication):
         """
 
         # This data should never be returned by the tests below because the course_id doesn't match.
-        G(models.ProblemFirstFinalResponseAnswerDistribution)
+        G(models.ProblemFirstLastResponseAnswerDistribution)
 
         # Create multiple objects here to test the grouping. Add a model with a different module_id to break up the
         # natural order and ensure the view properly sorts the objects before grouping.
@@ -607,12 +607,12 @@ class CourseProblemsListViewTests(DemoCourseMixin, TestCaseWithAuthentication):
         created = datetime.datetime.utcnow()
         alt_created = created + datetime.timedelta(seconds=2)
 
-        o1 = G(models.ProblemFirstFinalResponseAnswerDistribution, course_id=self.course_id, module_id=module_id,
-               correct=True, final_response_count=100, created=created)
-        o2 = G(models.ProblemFirstFinalResponseAnswerDistribution, course_id=self.course_id, module_id=alt_module_id,
-               correct=True, final_response_count=100, created=created)
-        o3 = G(models.ProblemFirstFinalResponseAnswerDistribution, course_id=self.course_id, module_id=module_id,
-               correct=False, final_response_count=200, created=alt_created)
+        o1 = G(models.ProblemFirstLastResponseAnswerDistribution, course_id=self.course_id, module_id=module_id,
+               correct=True, last_response_count=100, created=created)
+        o2 = G(models.ProblemFirstLastResponseAnswerDistribution, course_id=self.course_id, module_id=alt_module_id,
+               correct=True, last_response_count=100, created=created)
+        o3 = G(models.ProblemFirstLastResponseAnswerDistribution, course_id=self.course_id, module_id=module_id,
+               correct=False, last_response_count=200, created=alt_created)
 
         expected = [
             {

--- a/analytics_data_api/v0/tests/views/test_courses.py
+++ b/analytics_data_api/v0/tests/views/test_courses.py
@@ -607,12 +607,12 @@ class CourseProblemsListViewTests(DemoCourseMixin, TestCaseWithAuthentication):
         created = datetime.datetime.utcnow()
         alt_created = created + datetime.timedelta(seconds=2)
 
-        o1 = G(models.ProblemFirstLastResponseAnswerDistribution, course_id=self.course_id, module_id=module_id, correct=True,
-               final_response_count=100, created=created)
+        o1 = G(models.ProblemFirstLastResponseAnswerDistribution, course_id=self.course_id, module_id=module_id,
+               correct=True, final_response_count=100, created=created)
         o2 = G(models.ProblemFirstLastResponseAnswerDistribution, course_id=self.course_id, module_id=alt_module_id,
                correct=True, final_response_count=100, created=created)
-        o3 = G(models.ProblemFirstLastResponseAnswerDistribution, course_id=self.course_id, module_id=module_id, correct=False,
-               final_response_count=200, created=alt_created)
+        o3 = G(models.ProblemFirstLastResponseAnswerDistribution, course_id=self.course_id, module_id=module_id,
+               correct=False, final_response_count=200, created=alt_created)
 
         expected = [
             {

--- a/analytics_data_api/v0/tests/views/test_courses.py
+++ b/analytics_data_api/v0/tests/views/test_courses.py
@@ -598,7 +598,7 @@ class CourseProblemsListViewTests(DemoCourseMixin, TestCaseWithAuthentication):
         """
 
         # This data should never be returned by the tests below because the course_id doesn't match.
-        G(models.ProblemResponseAnswerDistribution)
+        G(models.ProblemFirstLastResponseAnswerDistribution)
 
         # Create multiple objects here to test the grouping. Add a model with a different module_id to break up the
         # natural order and ensure the view properly sorts the objects before grouping.
@@ -607,12 +607,12 @@ class CourseProblemsListViewTests(DemoCourseMixin, TestCaseWithAuthentication):
         created = datetime.datetime.utcnow()
         alt_created = created + datetime.timedelta(seconds=2)
 
-        o1 = G(models.ProblemResponseAnswerDistribution, course_id=self.course_id, module_id=module_id, correct=True,
-               count=100, created=created)
-        o2 = G(models.ProblemResponseAnswerDistribution, course_id=self.course_id, module_id=alt_module_id,
-               correct=True, count=100, created=created)
-        o3 = G(models.ProblemResponseAnswerDistribution, course_id=self.course_id, module_id=module_id, correct=False,
-               count=200, created=alt_created)
+        o1 = G(models.ProblemFirstLastResponseAnswerDistribution, course_id=self.course_id, module_id=module_id, correct=True,
+               final_response_count=100, created=created)
+        o2 = G(models.ProblemFirstLastResponseAnswerDistribution, course_id=self.course_id, module_id=alt_module_id,
+               correct=True, final_response_count=100, created=created)
+        o3 = G(models.ProblemFirstLastResponseAnswerDistribution, course_id=self.course_id, module_id=module_id, correct=False,
+               final_response_count=200, created=alt_created)
 
         expected = [
             {

--- a/analytics_data_api/v0/tests/views/test_courses.py
+++ b/analytics_data_api/v0/tests/views/test_courses.py
@@ -598,7 +598,7 @@ class CourseProblemsListViewTests(DemoCourseMixin, TestCaseWithAuthentication):
         """
 
         # This data should never be returned by the tests below because the course_id doesn't match.
-        G(models.ProblemFirstLastResponseAnswerDistribution)
+        G(models.ProblemFirstFinalResponseAnswerDistribution)
 
         # Create multiple objects here to test the grouping. Add a model with a different module_id to break up the
         # natural order and ensure the view properly sorts the objects before grouping.
@@ -607,11 +607,11 @@ class CourseProblemsListViewTests(DemoCourseMixin, TestCaseWithAuthentication):
         created = datetime.datetime.utcnow()
         alt_created = created + datetime.timedelta(seconds=2)
 
-        o1 = G(models.ProblemFirstLastResponseAnswerDistribution, course_id=self.course_id, module_id=module_id,
+        o1 = G(models.ProblemFirstFinalResponseAnswerDistribution, course_id=self.course_id, module_id=module_id,
                correct=True, final_response_count=100, created=created)
-        o2 = G(models.ProblemFirstLastResponseAnswerDistribution, course_id=self.course_id, module_id=alt_module_id,
+        o2 = G(models.ProblemFirstFinalResponseAnswerDistribution, course_id=self.course_id, module_id=alt_module_id,
                correct=True, final_response_count=100, created=created)
-        o3 = G(models.ProblemFirstLastResponseAnswerDistribution, course_id=self.course_id, module_id=module_id,
+        o3 = G(models.ProblemFirstFinalResponseAnswerDistribution, course_id=self.course_id, module_id=module_id,
                correct=False, final_response_count=200, created=alt_created)
 
         expected = [

--- a/analytics_data_api/v0/tests/views/test_problems.py
+++ b/analytics_data_api/v0/tests/views/test_problems.py
@@ -9,7 +9,7 @@ from django_dynamic_fixture import G
 import json
 
 from analytics_data_api.v0 import models
-from analytics_data_api.v0.serializers import ProblemFirstLastResponseAnswerDistributionSerializer, \
+from analytics_data_api.v0.serializers import ProblemFirstFinalResponseAnswerDistributionSerializer, \
     GradeDistributionSerializer, SequentialOpenDistributionSerializer
 from analyticsdataserver.tests import TestCaseWithAuthentication
 
@@ -32,7 +32,7 @@ class AnswerDistributionTests(TestCaseWithAuthentication):
         cls.question_text = 'Question Text'
 
         cls.ad1 = G(
-            models.ProblemFirstLastResponseAnswerDistribution,
+            models.ProblemFirstFinalResponseAnswerDistribution,
             course_id=cls.course_id,
             module_id=cls.module_id1,
             part_id=cls.part_id,
@@ -46,7 +46,7 @@ class AnswerDistributionTests(TestCaseWithAuthentication):
             final_reponse_count=3,
         )
         cls.ad2 = G(
-            models.ProblemFirstLastResponseAnswerDistribution,
+            models.ProblemFirstFinalResponseAnswerDistribution,
             course_id=cls.course_id,
             module_id=cls.module_id1,
             part_id=cls.part_id,
@@ -60,13 +60,13 @@ class AnswerDistributionTests(TestCaseWithAuthentication):
             final_response_count=2,
         )
         cls.ad3 = G(
-            models.ProblemFirstLastResponseAnswerDistribution,
+            models.ProblemFirstFinalResponseAnswerDistribution,
             course_id=cls.course_id,
             module_id=cls.module_id1,
             part_id=cls.part_id,
         )
         cls.ad4 = G(
-            models.ProblemFirstLastResponseAnswerDistribution,
+            models.ProblemFirstFinalResponseAnswerDistribution,
             course_id=cls.course_id,
             module_id=cls.module_id2,
             part_id=cls.part_id,
@@ -74,7 +74,7 @@ class AnswerDistributionTests(TestCaseWithAuthentication):
             correct=True,
         )
         cls.ad5 = G(
-            models.ProblemFirstLastResponseAnswerDistribution,
+            models.ProblemFirstFinalResponseAnswerDistribution,
             course_id=cls.course_id,
             module_id=cls.module_id2,
             part_id=cls.part_id,
@@ -82,7 +82,7 @@ class AnswerDistributionTests(TestCaseWithAuthentication):
             correct=True
         )
         cls.ad6 = G(
-            models.ProblemFirstLastResponseAnswerDistribution,
+            models.ProblemFirstFinalResponseAnswerDistribution,
             course_id=cls.course_id,
             module_id=cls.module_id2,
             part_id=cls.part_id,
@@ -95,8 +95,8 @@ class AnswerDistributionTests(TestCaseWithAuthentication):
         response = self.authenticated_get('/api/v0/problems/%s%s' % (self.module_id2, self.path))
         self.assertEquals(response.status_code, 200)
 
-        expected_data = models.ProblemFirstLastResponseAnswerDistribution.objects.filter(module_id=self.module_id2)
-        expected_data = [ProblemFirstLastResponseAnswerDistributionSerializer(answer).data for answer in expected_data]
+        expected_data = models.ProblemFirstFinalResponseAnswerDistribution.objects.filter(module_id=self.module_id2)
+        expected_data = [ProblemFirstFinalResponseAnswerDistributionSerializer(answer).data for answer in expected_data]
 
         for answer in expected_data:
             answer['consolidated_variant'] = False
@@ -113,8 +113,8 @@ class AnswerDistributionTests(TestCaseWithAuthentication):
         self.assertEquals(response.status_code, 200)
 
         expected_data = [
-            ProblemFirstLastResponseAnswerDistributionSerializer(self.ad1).data,
-            ProblemFirstLastResponseAnswerDistributionSerializer(self.ad3).data,
+            ProblemFirstFinalResponseAnswerDistributionSerializer(self.ad1).data,
+            ProblemFirstFinalResponseAnswerDistributionSerializer(self.ad3).data,
         ]
 
         expected_data[0]['first_response_count'] += self.ad2.first_response_count

--- a/analytics_data_api/v0/tests/views/test_problems.py
+++ b/analytics_data_api/v0/tests/views/test_problems.py
@@ -96,6 +96,11 @@ class AnswerDistributionTests(TestCaseWithAuthentication):
         self.assertEquals(response.status_code, 200)
 
         expected_data = models.ProblemFirstFinalResponseAnswerDistribution.objects.filter(module_id=self.module_id2)
+
+        # XXX: Remove when versioning is implemented.
+        for datum in expected_data:
+            datum.count = datum.final_response_count
+
         expected_data = [ProblemFirstFinalResponseAnswerDistributionSerializer(answer).data for answer in expected_data]
 
         for answer in expected_data:
@@ -112,16 +117,19 @@ class AnswerDistributionTests(TestCaseWithAuthentication):
             '/api/v0/problems/{0}{1}'.format(self.module_id1, self.path))
         self.assertEquals(response.status_code, 200)
 
-        expected_data = [
-            ProblemFirstFinalResponseAnswerDistributionSerializer(self.ad1).data,
-            ProblemFirstFinalResponseAnswerDistributionSerializer(self.ad3).data,
-        ]
+        expected_data = [self.ad1, self.ad3]
 
-        expected_data[0]['first_response_count'] += self.ad2.first_response_count
-        expected_data[0]['final_response_count'] += self.ad2.final_response_count
+        expected_data[0].first_response_count += self.ad2.first_response_count
+        expected_data[0].final_response_count += self.ad2.final_response_count
+
+        # XXX: Remove when versioning is implemented.
+        for datum in expected_data:
+            datum.count = datum.final_response_count
+
+        expected_data = [ProblemFirstFinalResponseAnswerDistributionSerializer(answer).data for answer in expected_data]
+
         expected_data[0]['variant'] = None
         expected_data[0]['consolidated_variant'] = True
-
         expected_data[1]['consolidated_variant'] = False
 
         response.data = set([json.dumps(answer) for answer in response.data])

--- a/analytics_data_api/v0/tests/views/test_problems.py
+++ b/analytics_data_api/v0/tests/views/test_problems.py
@@ -6,9 +6,10 @@
 # pylint: disable=no-member,no-value-for-parameter
 
 from django_dynamic_fixture import G
+import json
 
 from analytics_data_api.v0 import models
-from analytics_data_api.v0.serializers import ProblemResponseAnswerDistributionSerializer, \
+from analytics_data_api.v0.serializers import ProblemFirstLastResponseAnswerDistributionSerializer, \
     GradeDistributionSerializer, SequentialOpenDistributionSerializer
 from analyticsdataserver.tests import TestCaseWithAuthentication
 
@@ -31,7 +32,7 @@ class AnswerDistributionTests(TestCaseWithAuthentication):
         cls.question_text = 'Question Text'
 
         cls.ad1 = G(
-            models.ProblemResponseAnswerDistribution,
+            models.ProblemFirstLastResponseAnswerDistribution,
             course_id=cls.course_id,
             module_id=cls.module_id1,
             part_id=cls.part_id,
@@ -41,10 +42,11 @@ class AnswerDistributionTests(TestCaseWithAuthentication):
             problem_display_name=cls.problem_display_name,
             question_text=cls.question_text,
             variant=123,
-            count=1
+            first_response_count=1,
+            final_reponse_count=3,
         )
         cls.ad2 = G(
-            models.ProblemResponseAnswerDistribution,
+            models.ProblemFirstLastResponseAnswerDistribution,
             course_id=cls.course_id,
             module_id=cls.module_id1,
             part_id=cls.part_id,
@@ -54,16 +56,17 @@ class AnswerDistributionTests(TestCaseWithAuthentication):
             problem_display_name=cls.problem_display_name,
             question_text=cls.question_text,
             variant=345,
-            count=2
+            first_reponse_count=0,
+            final_response_count=2,
         )
         cls.ad3 = G(
-            models.ProblemResponseAnswerDistribution,
+            models.ProblemFirstLastResponseAnswerDistribution,
             course_id=cls.course_id,
             module_id=cls.module_id1,
             part_id=cls.part_id,
         )
         cls.ad4 = G(
-            models.ProblemResponseAnswerDistribution,
+            models.ProblemFirstLastResponseAnswerDistribution,
             course_id=cls.course_id,
             module_id=cls.module_id2,
             part_id=cls.part_id,
@@ -71,7 +74,7 @@ class AnswerDistributionTests(TestCaseWithAuthentication):
             correct=True,
         )
         cls.ad5 = G(
-            models.ProblemResponseAnswerDistribution,
+            models.ProblemFirstLastResponseAnswerDistribution,
             course_id=cls.course_id,
             module_id=cls.module_id2,
             part_id=cls.part_id,
@@ -79,7 +82,7 @@ class AnswerDistributionTests(TestCaseWithAuthentication):
             correct=True
         )
         cls.ad6 = G(
-            models.ProblemResponseAnswerDistribution,
+            models.ProblemFirstLastResponseAnswerDistribution,
             course_id=cls.course_id,
             module_id=cls.module_id2,
             part_id=cls.part_id,
@@ -92,11 +95,14 @@ class AnswerDistributionTests(TestCaseWithAuthentication):
         response = self.authenticated_get('/api/v0/problems/%s%s' % (self.module_id2, self.path))
         self.assertEquals(response.status_code, 200)
 
-        expected_data = models.ProblemResponseAnswerDistribution.objects.filter(module_id=self.module_id2)
-        expected_data = [ProblemResponseAnswerDistributionSerializer(answer).data for answer in expected_data]
+        expected_data = models.ProblemFirstLastResponseAnswerDistribution.objects.filter(module_id=self.module_id2)
+        expected_data = [ProblemFirstLastResponseAnswerDistributionSerializer(answer).data for answer in expected_data]
 
         for answer in expected_data:
             answer['consolidated_variant'] = False
+
+        response.data = set([json.dumps(answer) for answer in response.data])
+        expected_data = set([json.dumps(answer) for answer in expected_data])
 
         self.assertEqual(response.data, expected_data)
 
@@ -107,15 +113,19 @@ class AnswerDistributionTests(TestCaseWithAuthentication):
         self.assertEquals(response.status_code, 200)
 
         expected_data = [
-            ProblemResponseAnswerDistributionSerializer(self.ad1).data,
-            ProblemResponseAnswerDistributionSerializer(self.ad3).data,
+            ProblemFirstLastResponseAnswerDistributionSerializer(self.ad1).data,
+            ProblemFirstLastResponseAnswerDistributionSerializer(self.ad3).data,
         ]
 
-        expected_data[0]['count'] += self.ad2.count
+        expected_data[0]['first_response_count'] += self.ad2.first_response_count
+        expected_data[0]['final_response_count'] += self.ad2.final_response_count
         expected_data[0]['variant'] = None
         expected_data[0]['consolidated_variant'] = True
 
         expected_data[1]['consolidated_variant'] = False
+
+        response.data = set([json.dumps(answer) for answer in response.data])
+        expected_data = set([json.dumps(answer) for answer in expected_data])
 
         self.assertEquals(response.data, expected_data)
 

--- a/analytics_data_api/v0/tests/views/test_problems.py
+++ b/analytics_data_api/v0/tests/views/test_problems.py
@@ -9,7 +9,7 @@ from django_dynamic_fixture import G
 import json
 
 from analytics_data_api.v0 import models
-from analytics_data_api.v0.serializers import ProblemFirstFinalResponseAnswerDistributionSerializer, \
+from analytics_data_api.v0.serializers import ProblemFirstLastResponseAnswerDistributionSerializer, \
     GradeDistributionSerializer, SequentialOpenDistributionSerializer
 from analyticsdataserver.tests import TestCaseWithAuthentication
 
@@ -32,7 +32,7 @@ class AnswerDistributionTests(TestCaseWithAuthentication):
         cls.question_text = 'Question Text'
 
         cls.ad1 = G(
-            models.ProblemFirstFinalResponseAnswerDistribution,
+            models.ProblemFirstLastResponseAnswerDistribution,
             course_id=cls.course_id,
             module_id=cls.module_id1,
             part_id=cls.part_id,
@@ -43,10 +43,10 @@ class AnswerDistributionTests(TestCaseWithAuthentication):
             question_text=cls.question_text,
             variant=123,
             first_response_count=1,
-            final_reponse_count=3,
+            last_response_count=3,
         )
         cls.ad2 = G(
-            models.ProblemFirstFinalResponseAnswerDistribution,
+            models.ProblemFirstLastResponseAnswerDistribution,
             course_id=cls.course_id,
             module_id=cls.module_id1,
             part_id=cls.part_id,
@@ -57,16 +57,16 @@ class AnswerDistributionTests(TestCaseWithAuthentication):
             question_text=cls.question_text,
             variant=345,
             first_reponse_count=0,
-            final_response_count=2,
+            last_response_count=2,
         )
         cls.ad3 = G(
-            models.ProblemFirstFinalResponseAnswerDistribution,
+            models.ProblemFirstLastResponseAnswerDistribution,
             course_id=cls.course_id,
             module_id=cls.module_id1,
             part_id=cls.part_id,
         )
         cls.ad4 = G(
-            models.ProblemFirstFinalResponseAnswerDistribution,
+            models.ProblemFirstLastResponseAnswerDistribution,
             course_id=cls.course_id,
             module_id=cls.module_id2,
             part_id=cls.part_id,
@@ -74,7 +74,7 @@ class AnswerDistributionTests(TestCaseWithAuthentication):
             correct=True,
         )
         cls.ad5 = G(
-            models.ProblemFirstFinalResponseAnswerDistribution,
+            models.ProblemFirstLastResponseAnswerDistribution,
             course_id=cls.course_id,
             module_id=cls.module_id2,
             part_id=cls.part_id,
@@ -82,7 +82,7 @@ class AnswerDistributionTests(TestCaseWithAuthentication):
             correct=True
         )
         cls.ad6 = G(
-            models.ProblemFirstFinalResponseAnswerDistribution,
+            models.ProblemFirstLastResponseAnswerDistribution,
             course_id=cls.course_id,
             module_id=cls.module_id2,
             part_id=cls.part_id,
@@ -95,13 +95,13 @@ class AnswerDistributionTests(TestCaseWithAuthentication):
         response = self.authenticated_get('/api/v0/problems/%s%s' % (self.module_id2, self.path))
         self.assertEquals(response.status_code, 200)
 
-        expected_data = models.ProblemFirstFinalResponseAnswerDistribution.objects.filter(module_id=self.module_id2)
+        expected_data = models.ProblemFirstLastResponseAnswerDistribution.objects.filter(module_id=self.module_id2)
 
         # XXX: Remove when versioning is implemented.
         for datum in expected_data:
-            datum.count = datum.final_response_count
+            datum.count = datum.last_response_count
 
-        expected_data = [ProblemFirstFinalResponseAnswerDistributionSerializer(answer).data for answer in expected_data]
+        expected_data = [ProblemFirstLastResponseAnswerDistributionSerializer(answer).data for answer in expected_data]
 
         for answer in expected_data:
             answer['consolidated_variant'] = False
@@ -120,13 +120,13 @@ class AnswerDistributionTests(TestCaseWithAuthentication):
         expected_data = [self.ad1, self.ad3]
 
         expected_data[0].first_response_count += self.ad2.first_response_count
-        expected_data[0].final_response_count += self.ad2.final_response_count
+        expected_data[0].last_response_count += self.ad2.last_response_count
 
         # XXX: Remove when versioning is implemented.
         for datum in expected_data:
-            datum.count = datum.final_response_count
+            datum.count = datum.last_response_count
 
-        expected_data = [ProblemFirstFinalResponseAnswerDistributionSerializer(answer).data for answer in expected_data]
+        expected_data = [ProblemFirstLastResponseAnswerDistributionSerializer(answer).data for answer in expected_data]
 
         expected_data[0]['variant'] = None
         expected_data[0]['consolidated_variant'] = True

--- a/analytics_data_api/v0/views/courses.py
+++ b/analytics_data_api/v0/views/courses.py
@@ -4,7 +4,7 @@ import warnings
 
 from django.conf import settings
 from django.core.exceptions import ObjectDoesNotExist
-from django.db import connections, OperationalError
+from django.db import connections
 from django.db.models import Max
 from django.http import Http404
 from django.utils.timezone import make_aware, utc
@@ -634,11 +634,11 @@ class ProblemsListView(BaseCourseView):
     allow_empty = False
 
     def get_queryset(self):
-        sql = """
+        aggregation_query = """
 SELECT
     module_id,
-    SUM(count) AS total_submissions,
-    SUM(CASE WHEN correct=1 THEN count ELSE 0 END) AS correct_submissions,
+    SUM(final_response_count) AS total_submissions,
+    SUM(CASE WHEN correct=1 THEN final_response_count ELSE 0 END) AS correct_submissions,
     GROUP_CONCAT(DISTINCT part_id) AS part_ids,
     MAX(created) AS created
 FROM answer_distribution
@@ -654,10 +654,17 @@ GROUP BY module_id;
                 # http://code.openark.org/blog/mysql/those-oversized-undersized-variables-defaults.
                 cursor.execute("SET @@group_concat_max_len = @@max_allowed_packet;")
 
-            try:
-                cursor.execute(sql, [self.course_id])
-            except OperationalError:
-                cursor.execute(sql.replace('count', 'final_response_count'), [self.course_id])
+                cursor.execute("DESCRIBE answer_distribution;")
+                column_names = [row[0] for row in cursor.fetchall()]
+            # Alternate query for sqlite test database
+            else:
+                cursor.execute("PRAGMA table_info(answer_distribution)")
+                column_names = [row[1] for row in cursor.fetchall()]
+
+            if u'final_response_count' in column_names:
+                cursor.execute(aggregation_query, [self.course_id])
+            else:
+                cursor.execute(aggregation_query.replace('final_response_count', 'count'), [self.course_id])
 
             rows = dictfetchall(cursor)
 

--- a/analytics_data_api/v0/views/courses.py
+++ b/analytics_data_api/v0/views/courses.py
@@ -637,8 +637,8 @@ class ProblemsListView(BaseCourseView):
         aggregation_query = """
 SELECT
     module_id,
-    SUM(final_response_count) AS total_submissions,
-    SUM(CASE WHEN correct=1 THEN final_response_count ELSE 0 END) AS correct_submissions,
+    SUM(last_response_count) AS total_submissions,
+    SUM(CASE WHEN correct=1 THEN last_response_count ELSE 0 END) AS correct_submissions,
     GROUP_CONCAT(DISTINCT part_id) AS part_ids,
     MAX(created) AS created
 FROM answer_distribution
@@ -661,10 +661,10 @@ GROUP BY module_id;
                 cursor.execute("PRAGMA table_info(answer_distribution)")
                 column_names = [row[1] for row in cursor.fetchall()]
 
-            if u'final_response_count' in column_names:
+            if u'last_response_count' in column_names:
                 cursor.execute(aggregation_query, [self.course_id])
             else:
-                cursor.execute(aggregation_query.replace('final_response_count', 'count'), [self.course_id])
+                cursor.execute(aggregation_query.replace('last_response_count', 'count'), [self.course_id])
 
             rows = dictfetchall(cursor)
 

--- a/analytics_data_api/v0/views/problems.py
+++ b/analytics_data_api/v0/views/problems.py
@@ -61,6 +61,7 @@ class ProblemResponseAnswerDistributionView(generics.ListAPIView):
 
         try:
             queryset = list(ProblemResponseAnswerDistribution.objects.filter(module_id=problem_id).order_by('part_id'))
+        # pylint: disable=catching-non-exception
         except OperationalError:
             self.serializer_class = ConsolidatedFirstFinalAnswerDistributionSerializer
             queryset = list(ProblemFirstFinalResponseAnswerDistribution.objects.filter(
@@ -70,6 +71,11 @@ class ProblemResponseAnswerDistributionView(generics.ListAPIView):
 
         for _, part in groupby(queryset, lambda x: x.part_id):
             consolidated_rows += consolidate_answers(list(part))
+
+        # XXX: Remove this loop when proper versioning is implemented
+        for row in consolidated_rows:
+            if 'count' not in dir(row):
+                row.count = row.final_response_count
 
         return consolidated_rows
 

--- a/analytics_data_api/v0/views/problems.py
+++ b/analytics_data_api/v0/views/problems.py
@@ -6,8 +6,8 @@ from itertools import groupby
 
 from rest_framework import generics
 
-from analytics_data_api.v0.models import ProblemResponseAnswerDistribution
-from analytics_data_api.v0.serializers import ConsolidatedAnswerDistributionSerializer
+from analytics_data_api.v0.models import ProblemResponseAnswerDistribution, ProblemFirstLastResponseAnswerDistribution
+from analytics_data_api.v0.serializers import ConsolidatedAnswerDistributionSerializer, ConsolidatedFirstLastAnswerDistributionSerializer
 from analytics_data_api.v0.models import GradeDistribution
 from analytics_data_api.v0.serializers import GradeDistributionSerializer
 from analytics_data_api.v0.models import SequentialOpenDistribution
@@ -43,13 +43,6 @@ class ProblemResponseAnswerDistributionView(generics.ListAPIView):
             * variant: For randomized problems, the random seed used. If problem
               is not randomized, value is null.
             * created: The date the count was computed.
-
-    **Parameters**
-
-        You can request consolidation of response counts for erroneously randomized problems.
-
-        consolidate_variants -- If True, attempt to consolidate responses, otherwise, do not.
-
     """
 
     serializer_class = ConsolidatedAnswerDistributionSerializer
@@ -59,7 +52,11 @@ class ProblemResponseAnswerDistributionView(generics.ListAPIView):
         """Select all the answer distribution response having to do with this usage of the problem."""
         problem_id = self.kwargs.get('problem_id')
 
-        queryset = ProblemResponseAnswerDistribution.objects.filter(module_id=problem_id).order_by('part_id')
+        try:
+            queryset = list(ProblemResponseAnswerDistribution.objects.filter(module_id=problem_id).order_by('part_id'))
+        except:
+            self.serializer_class = ConsolidatedFirstLastAnswerDistributionSerializer
+            queryset = list(ProblemFirstLastResponseAnswerDistribution.objects.filter(module_id=problem_id).order_by('part_id'))
 
         consolidated_rows = []
 

--- a/analytics_data_api/v0/views/problems.py
+++ b/analytics_data_api/v0/views/problems.py
@@ -7,9 +7,9 @@ from itertools import groupby
 from django.db import OperationalError
 from rest_framework import generics
 
-from analytics_data_api.v0.models import ProblemResponseAnswerDistribution, ProblemFirstLastResponseAnswerDistribution
+from analytics_data_api.v0.models import ProblemResponseAnswerDistribution, ProblemFirstFinalResponseAnswerDistribution
 from analytics_data_api.v0.serializers import ConsolidatedAnswerDistributionSerializer, \
-    ConsolidatedFirstLastAnswerDistributionSerializer
+    ConsolidatedFirstFinalAnswerDistributionSerializer
 from analytics_data_api.v0.models import GradeDistribution
 from analytics_data_api.v0.serializers import GradeDistributionSerializer
 from analytics_data_api.v0.models import SequentialOpenDistribution
@@ -57,8 +57,8 @@ class ProblemResponseAnswerDistributionView(generics.ListAPIView):
         try:
             queryset = list(ProblemResponseAnswerDistribution.objects.filter(module_id=problem_id).order_by('part_id'))
         except OperationalError:
-            self.serializer_class = ConsolidatedFirstLastAnswerDistributionSerializer
-            queryset = list(ProblemFirstLastResponseAnswerDistribution.objects.filter(
+            self.serializer_class = ConsolidatedFirstFinalAnswerDistributionSerializer
+            queryset = list(ProblemFirstFinalResponseAnswerDistribution.objects.filter(
                 module_id=problem_id).order_by('part_id'))
 
         consolidated_rows = []

--- a/analytics_data_api/v0/views/problems.py
+++ b/analytics_data_api/v0/views/problems.py
@@ -10,12 +10,12 @@ from rest_framework import generics
 from analytics_data_api.v0.models import (
     GradeDistribution,
     ProblemResponseAnswerDistribution,
-    ProblemFirstFinalResponseAnswerDistribution,
+    ProblemFirstLastResponseAnswerDistribution,
     SequentialOpenDistribution,
 )
 from analytics_data_api.v0.serializers import (
     ConsolidatedAnswerDistributionSerializer,
-    ConsolidatedFirstFinalAnswerDistributionSerializer,
+    ConsolidatedFirstLastAnswerDistributionSerializer,
     GradeDistributionSerializer,
     SequentialOpenDistributionSerializer,
 )
@@ -63,8 +63,8 @@ class ProblemResponseAnswerDistributionView(generics.ListAPIView):
             queryset = list(ProblemResponseAnswerDistribution.objects.filter(module_id=problem_id).order_by('part_id'))
         # pylint: disable=catching-non-exception
         except OperationalError:
-            self.serializer_class = ConsolidatedFirstFinalAnswerDistributionSerializer
-            queryset = list(ProblemFirstFinalResponseAnswerDistribution.objects.filter(
+            self.serializer_class = ConsolidatedFirstLastAnswerDistributionSerializer
+            queryset = list(ProblemFirstLastResponseAnswerDistribution.objects.filter(
                 module_id=problem_id).order_by('part_id'))
 
         consolidated_rows = []
@@ -75,7 +75,7 @@ class ProblemResponseAnswerDistributionView(generics.ListAPIView):
         # XXX: Remove this loop when proper versioning is implemented
         for row in consolidated_rows:
             if 'count' not in dir(row):
-                row.count = row.final_response_count
+                row.count = row.last_response_count
 
         return consolidated_rows
 

--- a/analytics_data_api/v0/views/problems.py
+++ b/analytics_data_api/v0/views/problems.py
@@ -7,13 +7,18 @@ from itertools import groupby
 from django.db import OperationalError
 from rest_framework import generics
 
-from analytics_data_api.v0.models import ProblemResponseAnswerDistribution, ProblemFirstFinalResponseAnswerDistribution
-from analytics_data_api.v0.serializers import ConsolidatedAnswerDistributionSerializer, \
-    ConsolidatedFirstFinalAnswerDistributionSerializer
-from analytics_data_api.v0.models import GradeDistribution
-from analytics_data_api.v0.serializers import GradeDistributionSerializer
-from analytics_data_api.v0.models import SequentialOpenDistribution
-from analytics_data_api.v0.serializers import SequentialOpenDistributionSerializer
+from analytics_data_api.v0.models import (
+    GradeDistribution,
+    ProblemResponseAnswerDistribution,
+    ProblemFirstFinalResponseAnswerDistribution,
+    SequentialOpenDistribution,
+)
+from analytics_data_api.v0.serializers import (
+    ConsolidatedAnswerDistributionSerializer,
+    ConsolidatedFirstFinalAnswerDistributionSerializer,
+    GradeDistributionSerializer,
+    SequentialOpenDistributionSerializer,
+)
 from analytics_data_api.utils import consolidate_answers
 
 

--- a/analytics_data_api/v0/views/problems.py
+++ b/analytics_data_api/v0/views/problems.py
@@ -4,10 +4,12 @@ API methods for module level data.
 
 from itertools import groupby
 
+from django.db import OperationalError
 from rest_framework import generics
 
 from analytics_data_api.v0.models import ProblemResponseAnswerDistribution, ProblemFirstLastResponseAnswerDistribution
-from analytics_data_api.v0.serializers import ConsolidatedAnswerDistributionSerializer, ConsolidatedFirstLastAnswerDistributionSerializer
+from analytics_data_api.v0.serializers import ConsolidatedAnswerDistributionSerializer, \
+    ConsolidatedFirstLastAnswerDistributionSerializer
 from analytics_data_api.v0.models import GradeDistribution
 from analytics_data_api.v0.serializers import GradeDistributionSerializer
 from analytics_data_api.v0.models import SequentialOpenDistribution
@@ -54,9 +56,10 @@ class ProblemResponseAnswerDistributionView(generics.ListAPIView):
 
         try:
             queryset = list(ProblemResponseAnswerDistribution.objects.filter(module_id=problem_id).order_by('part_id'))
-        except:
+        except OperationalError:
             self.serializer_class = ConsolidatedFirstLastAnswerDistributionSerializer
-            queryset = list(ProblemFirstLastResponseAnswerDistribution.objects.filter(module_id=problem_id).order_by('part_id'))
+            queryset = list(ProblemFirstLastResponseAnswerDistribution.objects.filter(
+                module_id=problem_id).order_by('part_id'))
 
         consolidated_rows = []
 


### PR DESCRIPTION
This adds the ability to record users' first attempts to answer questions to the answer_distribution table.  There is an open, associated PR against edx/edx-analytics-data-api which has more discussion on the value and merits of various design choices.  The only differences between that PR and this one is that in this one, the description 'final' has been replaced by the description 'last' for all usages and that this version emits a duplicate entry in its JSON responses named 'count' which has the same value as 'last_response_count'.

This should be useful while I'm gone this week for developing against.  It would also be nice to have it reviewed so that it's ready to go when spring quarter starts.  @dcadams @stvstnfrd @ataki
